### PR TITLE
Do not store in Redis exceptions.

### DIFF
--- a/redis_lru/lru.py
+++ b/redis_lru/lru.py
@@ -25,12 +25,12 @@ class RedisLRU:
                  default_ttl=15 * 60,
                  key_prefix='RedisLRU',
                  clear_on_exit=False,
-                 exceptions=None):
+                 exclude_values=None):
         self.client = client
         self.max_size = max_size
         self.key_prefix = key_prefix
         self.default_ttl = default_ttl
-        self.exceptions = exceptions if type(exceptions) is list else list()
+        self.exclude_values = exclude_values if type(exclude_values) is set else set()
 
         if clear_on_exit:
             atexit.register(self.clear_all_cache)
@@ -76,7 +76,7 @@ class RedisLRU:
             return pickle.loads(result)
 
     def set(self, key, value, ttl=None):
-        if value in self.exceptions:
+        if value in self.exclude_values:
             return
         ttl = ttl or self.default_ttl
         value = pickle.dumps(value)

--- a/redis_lru/lru.py
+++ b/redis_lru/lru.py
@@ -24,11 +24,13 @@ class RedisLRU:
                  max_size=2 ** 20,
                  default_ttl=15 * 60,
                  key_prefix='RedisLRU',
-                 clear_on_exit=False):
+                 clear_on_exit=False,
+                 exceptions=None):
         self.client = client
         self.max_size = max_size
         self.key_prefix = key_prefix
         self.default_ttl = default_ttl
+        self.exceptions = exceptions if type(exceptions) is list else list()
 
         if clear_on_exit:
             atexit.register(self.clear_all_cache)
@@ -74,6 +76,8 @@ class RedisLRU:
             return pickle.loads(result)
 
     def set(self, key, value, ttl=None):
+        if value in self.exceptions:
+            return
         ttl = ttl or self.default_ttl
         value = pickle.dumps(value)
         return self.client.setex(key, ttl, value)
@@ -118,4 +122,3 @@ class RedisLRU:
 
         return '{}:{}:{}{!r}:{!r}'.format(self.key_prefix, func.__module__,
                                           func.__qualname__, args, kwargs)
-

--- a/redis_lru/tests.py
+++ b/redis_lru/tests.py
@@ -62,7 +62,7 @@ class RedisLRUTest(unittest.TestCase):
         self.assertEqual(flag, 2)
 
     def test_exclude(self):
-        cache = self.get_cache(exceptions=[20])
+        cache = self.get_cache(exclude_values={20})
 
         flag = 0
 


### PR DESCRIPTION
Hi,

this PR allow to add some values to exceptions list. Redis-lru will not cache values from exceptions list.

client = redis.StrictRedis()
return RedisLRU(client, exceptions=[None, 0, False, 'wrong_value'])