### PR TITLE
fix bug, remove unnessary codes

### DIFF
--- a/redis_lru/lru.py
+++ b/redis_lru/lru.py
@@ -62,12 +62,6 @@ class RedisLRU:
                     self.set(key, result, _ttl)
                     return result
 
-        # decorator without arguments
-        if callable(ttl):
-            func = ttl
-            ttl = 60 * 15
-            return wraps(func)(inner)
-
         # decorator with arguments
         def wrapper(f):
             nonlocal func


### PR DESCRIPTION
Following codes bring bugs when no params provided for the decorator
```
if callable(ttl):
    func = ttl
    ttl = 60 * 15
    return wraps(func)(inner)
```
the ttl will ways be 60 *15 , cuz when params is not provided for the decorator, the **ttl** param here will always became the function being wrapped, which will always lead this statemet to TRUE, and the **default_ttl** will not work too 